### PR TITLE
feat: implement full nginx API proxy with proper routing

### DIFF
--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -61,30 +61,30 @@ export const api = createApi({
   tagTypes: ["DashboardMetrics", "Products", "Users", "Expenses"],
   endpoints: (build) => ({
     getDashboardMetrics: build.query<DashboardMetrics, void>({
-      query: () => "/dashboard",
+      query: () => "/api/dashboard",
       providesTags: ["DashboardMetrics"] 
     }),
     getProducts: build.query<Product[], string | void>({
       query: (search) => ({
-        url: "/products",
+        url: "/api/products",
         params: search ? { search } : {}
       }),
       providesTags: ["Products"]
     }),
     createProduct: build.mutation<Product, NewProduct>({
       query: (newProduct) => ({
-        url: "/products",
+        url: "/api/products",
         method: "POST",
         body: newProduct
       }),
       invalidatesTags: ["Products"]
     }),
     getUsers: build.query<User[], void>({
-      query: () => "/users",
+      query: () => "/api/users",
       providesTags: ["Users"],
     }),
     getExpensesByCategory: build.query<ExpenseByCategorySummary[], void>({
-      query: () => "/expenses",
+      query: () => "/api/expenses",
       providesTags: ["Expenses"],
     }),
   })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,11 @@ services:
       - DOCKER_ENV=true
     env_file:
       - ./server/.env.docker
-    ports:
-      - "8000:8000"
     depends_on:
       postgres:
         condition: service_healthy
+    expose:
+      - "8000"
     volumes:
       - /app/node_modules
     networks:

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -27,7 +27,7 @@ const corsOptions = {
   origin: [
     process.env.NODE_ENV === 'production' 
       ? 'https://yourdomain.com' 
-      : 'http://frontend:3000', // Docker service name
+      : 'http://frontend', // Docker service name
     'http://localhost:3000' // Fallback for local dev
   ],
   credentials: true,
@@ -44,10 +44,10 @@ if (process.env.SERVE_STATIC_IMAGES === 'true' && !process.env.DOCKER_ENV) {
 }
 
 /* ROUTES */
-app.use("/dashboard", dashboardRoutes); // http://localhost:8000/dashboard
-app.use("/products", productRoutes); // http://localhost:8000/products
-app.use("/users", userRoutes); // http://localhost:8000/users
-app.use("/expenses", expenseRoutes) // http://localhost:8000/expenses
+app.use("/api/dashboard", dashboardRoutes); // http://localhost:8000/dashboard
+app.use("/api/products", productRoutes); // http://localhost:8000/products
+app.use("/api/users", userRoutes); // http://localhost:8000/users
+app.use("/api/expenses", expenseRoutes) // http://localhost:8000/expenses
 
 
 // health check route


### PR DESCRIPTION
feat: implement full nginx API proxy with proper routing

- Add /api prefix to all backend routes (dashboard, products, users, expenses)
- Update Redux RTK Query endpoints to use /api prefix in API calls
- Remove backend port mapping from docker-compose.yml (8000:8000)
- Configure client to use http://localhost (nginx) instead of :8000
- Update CORS to allow requests through nginx proxy
- All API calls now properly flow: frontend → nginx → backend
- Static files continue serving through nginx at /static
- Complete single-entry-point architecture achieved